### PR TITLE
Upgrade deasync to kill process._tickDomainCallback error

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "app-root-path": "1.3.0",
     "babel-runtime": "6.11.6",
-    "deasync": "0.1.7",
+    "deasync": "0.1.12",
     "debug": "2.6.1",
     "deep-extend": "0.4.1",
     "fs-promise": "0.5.0",


### PR DESCRIPTION
https://github.com/abbr/deasync/issues/89

In newer versions of node, this version of deasync triggers a `process._tickDomainCallback error`. Bumping the version fixes this.